### PR TITLE
Use env bash she-bang for portability

### DIFF
--- a/get-windows-updates-from-packer-log.sh
+++ b/get-windows-updates-from-packer-log.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eu
 grep 'Found Windows update ' "$1" \
     | sed -E 's,\x1b[^m]+m,,g' \


### PR DESCRIPTION
On systems that do not have a standard filesystem layout or are not a Linux base (eg. Free-/OpenBSD), `/bin/bash` may not exist.
Using `/usr/bin/env bash` is therefore [considered the more portable way](https://en.wikipedia.org/w/index.php?title=Shebang_(Unix)#Portability) of setting the shebang.

