### PR TITLE
QEMU 7.1 compatibility audiodev as pulseaudio

### DIFF
--- a/windows-10-20h2.pkr.hcl
+++ b/windows-10-20h2.pkr.hcl
@@ -43,7 +43,7 @@ source "qemu" "windows-10-20h2-amd64" {
   memory       = 4096
   qemuargs = [
     ["-cpu", "host"],
-    ["-soundhw", "hda"],
+    ["-audiodev", "id=pa,driver=pa"],
     ["-device", "qemu-xhci"],
     ["-device", "virtio-tablet"],
     ["-device", "virtio-scsi-pci,id=scsi0"],

--- a/windows-11-21h2-uefi.pkr.hcl
+++ b/windows-11-21h2-uefi.pkr.hcl
@@ -34,7 +34,7 @@ source "qemu" "windows-11-21h2-uefi-amd64" {
   qemuargs = [
     ["-bios", "/usr/share/ovmf/OVMF.fd"],
     ["-cpu", "host"],
-    ["-soundhw", "hda"],
+    ["-audiodev", "id=pa,driver=pa"],
     ["-device", "qemu-xhci"],
     ["-device", "virtio-tablet"],
     ["-device", "virtio-scsi-pci,id=scsi0"],

--- a/windows-11-21h2.pkr.hcl
+++ b/windows-11-21h2.pkr.hcl
@@ -43,7 +43,7 @@ source "qemu" "windows-11-21h2-amd64" {
   memory       = 4096
   qemuargs = [
     ["-cpu", "host"],
-    ["-soundhw", "hda"],
+    ["-audiodev", "id=pa,driver=pa"],
     ["-device", "qemu-xhci"],
     ["-device", "virtio-tablet"],
     ["-device", "virtio-scsi-pci,id=scsi0"],

--- a/windows-2019-uefi.pkr.hcl
+++ b/windows-2019-uefi.pkr.hcl
@@ -34,7 +34,7 @@ source "qemu" "windows-2019-uefi-amd64" {
   qemuargs = [
     ["-bios", "/usr/share/ovmf/OVMF.fd"],
     ["-cpu", "host"],
-    ["-soundhw", "hda"],
+    ["-audiodev", "id=pa,driver=pa"],
     ["-device", "qemu-xhci"],
     ["-device", "virtio-tablet"],
     ["-device", "virtio-scsi-pci,id=scsi0"],

--- a/windows-2019.pkr.hcl
+++ b/windows-2019.pkr.hcl
@@ -43,7 +43,7 @@ source "qemu" "windows-2019-amd64" {
   memory       = 4096
   qemuargs = [
     ["-cpu", "host"],
-    ["-soundhw", "hda"],
+    ["-audiodev", "id=pa,driver=pa"],
     ["-device", "qemu-xhci"],
     ["-device", "virtio-tablet"],
     ["-device", "virtio-scsi-pci,id=scsi0"],

--- a/windows-2022-uefi.pkr.hcl
+++ b/windows-2022-uefi.pkr.hcl
@@ -34,7 +34,7 @@ source "qemu" "windows-2022-uefi-amd64" {
   qemuargs = [
     ["-bios", "/usr/share/ovmf/OVMF.fd"],
     ["-cpu", "host"],
-    ["-soundhw", "hda"],
+    ["-audiodev", "id=pa,driver=pa"],
     ["-device", "qemu-xhci"],
     ["-device", "virtio-tablet"],
     ["-device", "virtio-scsi-pci,id=scsi0"],

--- a/windows-2022.pkr.hcl
+++ b/windows-2022.pkr.hcl
@@ -43,7 +43,7 @@ source "qemu" "windows-2022-amd64" {
   memory       = 4096
   qemuargs = [
     ["-cpu", "host"],
-    ["-soundhw", "hda"],
+    ["-audiodev", "id=pa,driver=pa"],
     ["-device", "qemu-xhci"],
     ["-device", "virtio-tablet"],
     ["-device", "virtio-scsi-pci,id=scsi0"],


### PR DESCRIPTION
Updated packer files with new qemu parameter for audio device. Besides of `none`, alternatively instead of pulseaudio (pa), open sound system (oss) is available. Build now finishing successfully on qemu 7.1.0-5 (arch linux).
Old version with `-soundhw` was removed, more here: https://www.qemu.org/docs/master/about/removed-features.html?highlight=soundhw