### PR TITLE
Use /usr/bin/env to make bash script work on more platform

### DIFF
--- a/box-metadata.sh
+++ b/box-metadata.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 provider="$1"

--- a/windows-evaluation-isos-update.sh
+++ b/windows-evaluation-isos-update.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # this updates the local windows-evaluation-isos.json file from the data at:
 # https://github.com/rgl/windows-evaluation-isos-scraper/tree/main/data
 set -euo pipefail


### PR DESCRIPTION
On some linux distro (guix, nix, alpine), some BSD and macos, bash is not located in `/bin`. On the other hand, `/usr/bin/env` is known to work on all these systems.

I'm on NixOS and this commit allows the build to complete for me.

And btw, Thanks for this repo, it is very useful!