### PR TITLE
reduce the number of jq spawns by make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,12 +10,19 @@ MAKEFLAGS+= --no-builtin-variables
 #export PACKER_PLUGIN_PATH:= $(HOME)/Projects/packer-plugin-windows-update/dist/test/plugins
 
 # NB execute windows-evaluation-isos-update.sh to update windows-evaluation-isos.json.
-export WINDOWS_11_ISO_URL?= $(shell jq -r '.["windows-11"].url' windows-evaluation-isos.json)
-export WINDOWS_11_ISO_CHECKSUM?= sha256:$(shell jq -r '.["windows-11"].checksum' windows-evaluation-isos.json)
-export WINDOWS_2022_ISO_URL?= $(shell jq -r '.["windows-2022"].url' windows-evaluation-isos.json)
-export WINDOWS_2022_ISO_CHECKSUM?= sha256:$(shell jq -r '.["windows-2022"].checksum' windows-evaluation-isos.json)
-export WINDOWS_2025_ISO_URL?= $(shell jq -r '.["windows-2025"].url' windows-evaluation-isos.json)
-export WINDOWS_2025_ISO_CHECKSUM?= sha256:$(shell jq -r '.["windows-2025"].checksum' windows-evaluation-isos.json)
+WINDOWS_11_ISO_URL?= $(shell jq -r '.["windows-11"].url' windows-evaluation-isos.json)
+WINDOWS_11_ISO_CHECKSUM?= sha256:$(shell jq -r '.["windows-11"].checksum' windows-evaluation-isos.json)
+WINDOWS_2022_ISO_URL?= $(shell jq -r '.["windows-2022"].url' windows-evaluation-isos.json)
+WINDOWS_2022_ISO_CHECKSUM?= sha256:$(shell jq -r '.["windows-2022"].checksum' windows-evaluation-isos.json)
+WINDOWS_2025_ISO_URL?= $(shell jq -r '.["windows-2025"].url' windows-evaluation-isos.json)
+WINDOWS_2025_ISO_CHECKSUM?= sha256:$(shell jq -r '.["windows-2025"].checksum' windows-evaluation-isos.json)
+
+export WINDOWS_11_ISO_URL:= $(WINDOWS_11_ISO_URL)
+export WINDOWS_11_ISO_CHECKSUM:= $(WINDOWS_11_ISO_CHECKSUM)
+export WINDOWS_2022_ISO_URL:= $(WINDOWS_2022_ISO_URL)
+export WINDOWS_2022_ISO_CHECKSUM:= $(WINDOWS_2022_ISO_CHECKSUM)
+export WINDOWS_2025_ISO_URL:= $(WINDOWS_2025_ISO_URL)
+export WINDOWS_2025_ISO_CHECKSUM:= $(WINDOWS_2025_ISO_CHECKSUM)
 
 # libvirt images.
 IMAGES+= windows-2022


### PR DESCRIPTION
When a make variable is not set, 'VAR?= content' sets it as a "recursively expanded" variable, meaning that the expansion of any other variables or functions referenced in its content is delayed until this variable is expanded.  When such a variable is exported, the expansion of its content also occurs just before each subprocess creation for which a corresponding environment variable has to be set.

In this Makefile this resulted in a large number of 'jq' processes being spawned, which is costly on (some?) Windows systems.

Avoid this by transforming the variables into simply expanded variables after the conditional adjustments (and export them at this point).